### PR TITLE
Fix API response mapping: Replace Total field with QueryInfo object

### DIFF
--- a/Jellyfin.Plugin.MediathekViewDL/Api/QueryInfo.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Api/QueryInfo.cs
@@ -1,0 +1,47 @@
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.MediathekViewDL.Api;
+
+#nullable disable
+
+/// <summary>
+/// Contains metadata about the search query results.
+/// </summary>
+public class QueryInfo
+{
+    /// <summary>
+    /// Gets or sets the timestamp of the film list used.
+    /// </summary>
+    [JsonPropertyName("filmlisteTimestamp")]
+    public long FilmlisteTimestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the time taken by the search engine.
+    /// </summary>
+    [JsonPropertyName("searchEngineTime")]
+    public string SearchEngineTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of results returned in this response.
+    /// </summary>
+    [JsonPropertyName("resultCount")]
+    public int ResultCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of results found for the query.
+    /// </summary>
+    [JsonPropertyName("totalResults")]
+    public int TotalResults { get; set; }
+
+    /// <summary>
+    /// Gets or sets the relation of the total results (e.g. "eq").
+    /// </summary>
+    [JsonPropertyName("totalRelation")]
+    public string TotalRelation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of entries in the database.
+    /// </summary>
+    [JsonPropertyName("totalEntries")]
+    public long TotalEntries { get; set; }
+}

--- a/Jellyfin.Plugin.MediathekViewDL/Api/ResultChannels.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Api/ResultChannels.cs
@@ -18,8 +18,8 @@ public class ResultChannels
     public Collection<ResultItem> Results { get; init; }
 
     /// <summary>
-    /// Gets or sets the total number of results.
+    /// Gets or sets the query info.
     /// </summary>
-    [JsonPropertyName("total")]
-    public int Total { get; set; }
+    [JsonPropertyName("queryInfo")]
+    public QueryInfo QueryInfo { get; set; }
 }

--- a/Jellyfin.Plugin.MediathekViewDL/Tasks/DownloadScheduledTask.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Tasks/DownloadScheduledTask.cs
@@ -138,7 +138,7 @@ public class DownloadScheduledTask : IScheduledTask
                 };
 
                 var result = await _apiClient.SearchAsync(apiQuery, cancellationToken).ConfigureAwait(false);
-                if (result?.Total > (currentPage + 1) * pageSize)
+                if (result?.QueryInfo?.TotalResults > (currentPage + 1) * pageSize)
                 {
                     hasMoreResults = true;
                     currentPage++;

--- a/MediathekViewDL_API.md
+++ b/MediathekViewDL_API.md
@@ -66,8 +66,12 @@ Die Antwort ist ein JSON-Objekt, das die Suchergebnisse enthält.
       }
     ],
     "queryInfo": {
-      "resultCount": 1,
-      "totalResults": 100
+      "filmlisteTimestamp" : 1765124760,
+      "searchEngineTime" : "4.67",
+      "resultCount" : 100,
+      "totalResults" : 1,
+      "totalRelation" : "eq",
+      "totalEntries" : 689777
     }
   },
   "err": null


### PR DESCRIPTION
 Summary
  This PR fixes a bug in the API response mapping where ResultChannels incorrectly expected a flat Total integer field. The MediathekViewWeb API actually returns a queryInfo object containing metadata    
  about the results. This mismatch caused the total result count to be zero (default int value), potentially breaking pagination logic.

  Changes
   - Added `QueryInfo` class: Created a new model Jellyfin.Plugin.MediathekViewDL/Api/QueryInfo.cs to correctly represent the queryInfo JSON object returned by the API (including fields like totalResults,
     resultCount, filmlisteTimestamp, etc.).
   - Updated `ResultChannels`: Replaced the incorrect int Total property with QueryInfo QueryInfo.
   - Updated `DownloadScheduledTask`: Adjusted the pagination logic to access the total results count via result.QueryInfo.TotalResults.
   - Documentation: Updated MediathekViewDL_API.md to reflect the correct JSON structure of the API response.