### PR TITLE
Refactor DownloadScheduledTask into SubscriptionProcessor and DownloadManager

### DIFF
--- a/Jellyfin.Plugin.MediathekViewDL/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/ServiceRegistrator.cs
@@ -24,6 +24,8 @@ namespace Jellyfin.Plugin.MediathekViewDL
             serviceCollection.AddTransient<MediathekViewDlApiService>();
             serviceCollection.AddTransient<FFmpegService>();
             serviceCollection.AddTransient<FileDownloader>();
+            serviceCollection.AddTransient<SubscriptionProcessor>();
+            serviceCollection.AddTransient<DownloadManager>();
         }
     }
 }

--- a/Jellyfin.Plugin.MediathekViewDL/Services/DownloadJob.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Services/DownloadJob.cs
@@ -1,0 +1,39 @@
+namespace Jellyfin.Plugin.MediathekViewDL.Services;
+
+/// <summary>
+/// Represents a unit of work for the download manager.
+/// </summary>
+public class DownloadJob
+{
+    /// <summary>
+    /// Gets or sets the unique identifier of the MediathekView result item.
+    /// Used for tracking processed items.
+    /// </summary>
+    public string ItemId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the source URL (Video URL, Subtitle URL, etc.).
+    /// </summary>
+    public string SourceUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the full local path where the result should be saved.
+    /// </summary>
+    public string DestinationPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the type of operation to perform.
+    /// </summary>
+    public DownloadType JobType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the language code for audio extraction (e.g., "deu", "eng").
+    /// Required only if <see cref="JobType"/> is <see cref="DownloadType.AudioExtraction"/>.
+    /// </summary>
+    public string? AudioLanguage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the title of the video/content. Used primarily for logging.
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+}

--- a/Jellyfin.Plugin.MediathekViewDL/Services/DownloadManager.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Services/DownloadManager.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.MediathekViewDL.Services;
+
+/// <summary>
+/// Service responsible for executing download jobs.
+/// </summary>
+public class DownloadManager
+{
+    private readonly ILogger<DownloadManager> _logger;
+    private readonly FileDownloader _fileDownloader;
+    private readonly FFmpegService _ffmpegService;
+    private readonly IServerApplicationPaths _appPaths;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DownloadManager"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="fileDownloader">The file downloader service.</param>
+    /// <param name="ffmpegService">The FFmpeg service.</param>
+    /// <param name="appPaths">The application paths.</param>
+    public DownloadManager(
+        ILogger<DownloadManager> logger,
+        FileDownloader fileDownloader,
+        FFmpegService ffmpegService,
+        IServerApplicationPaths appPaths)
+    {
+        _logger = logger;
+        _fileDownloader = fileDownloader;
+        _ffmpegService = ffmpegService;
+        _appPaths = appPaths;
+    }
+
+    /// <summary>
+    /// Executes a single download job.
+    /// </summary>
+    /// <param name="job">The job to execute.</param>
+    /// <param name="progress">The progress reporter.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>True if the job was successful (or file already existed), otherwise false.</returns>
+    public async Task<bool> ExecuteJobAsync(DownloadJob job, IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        if (File.Exists(job.DestinationPath))
+        {
+            _logger.LogDebug("File '{Path}' already exists. Skipping download.", job.DestinationPath);
+            progress.Report(100);
+            return true;
+        }
+
+        var directory = Path.GetDirectoryName(job.DestinationPath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            try
+            {
+                Directory.CreateDirectory(directory);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create directory '{Directory}'.", directory);
+                return false;
+            }
+        }
+
+        bool success = false;
+
+        switch (job.JobType)
+        {
+            case DownloadType.StreamingUrl:
+                _logger.LogInformation("Creating streaming URL file for '{Title}' at '{Path}'.", job.Title, job.DestinationPath);
+                success = await _fileDownloader.GenerateStreamingUrlFileAsync(job.SourceUrl, job.DestinationPath, cancellationToken).ConfigureAwait(false);
+                break;
+
+            case DownloadType.DirectDownload:
+                _logger.LogInformation("Downloading '{Title}' to '{Path}'.", job.Title, job.DestinationPath);
+                success = await _fileDownloader.DownloadFileAsync(job.SourceUrl, job.DestinationPath, progress, cancellationToken).ConfigureAwait(false);
+                break;
+
+            case DownloadType.AudioExtraction:
+                var tempVideoPath = Path.Combine(_appPaths.TempDirectory, $"{Guid.NewGuid()}.mp4");
+                _logger.LogInformation("Downloading temporary video for '{Title}' to extract '{Language}' audio.", job.Title, job.AudioLanguage);
+
+                // Track progress for the download part (0-80%)
+                var downloadProgress = new Progress<double>(p => progress.Report(p * 0.8));
+
+                if (await _fileDownloader.DownloadFileAsync(job.SourceUrl, tempVideoPath, downloadProgress, cancellationToken).ConfigureAwait(false))
+                {
+                    _logger.LogInformation("Extracting '{Language}' audio for '{Title}' to '{Path}'.", job.AudioLanguage, job.Title, job.DestinationPath);
+                    progress.Report(85);
+                    success = await _ffmpegService.ExtractAudioAsync(tempVideoPath, job.DestinationPath, job.AudioLanguage ?? "und", cancellationToken).ConfigureAwait(false);
+
+                    if (success)
+                    {
+                        _logger.LogInformation("Successfully extracted '{Language}' audio for '{Title}'.", job.AudioLanguage, job.Title);
+                    }
+                    else
+                    {
+                        _logger.LogError("Failed to extract audio for '{Title}'.", job.Title);
+                    }
+
+                    // Clean up
+                    try
+                    {
+                        if (File.Exists(tempVideoPath))
+                        {
+                            File.Delete(tempVideoPath);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                         _logger.LogWarning(ex, "Failed to delete temporary file '{TempPath}'.", tempVideoPath);
+                    }
+                }
+                else
+                {
+                    _logger.LogError("Failed to download temporary video for '{Title}'.", job.Title);
+                    success = false;
+                }
+
+                break;
+
+            default:
+                _logger.LogError("Unknown download type: {Type}", job.JobType);
+                success = false;
+                break;
+        }
+
+        if (success)
+        {
+            progress.Report(100);
+        }
+
+        return success;
+    }
+}

--- a/Jellyfin.Plugin.MediathekViewDL/Services/DownloadType.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Services/DownloadType.cs
@@ -1,0 +1,22 @@
+namespace Jellyfin.Plugin.MediathekViewDL.Services;
+
+/// <summary>
+/// Defines the type of download job.
+/// </summary>
+public enum DownloadType
+{
+    /// <summary>
+    /// Direct file download (e.g. video, subtitle).
+    /// </summary>
+    DirectDownload,
+
+    /// <summary>
+    /// Extract audio from video.
+    /// </summary>
+    AudioExtraction,
+
+    /// <summary>
+    /// Create a streaming URL file (.strm).
+    /// </summary>
+    StreamingUrl
+}

--- a/Jellyfin.Plugin.MediathekViewDL/Services/SubscriptionProcessor.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Services/SubscriptionProcessor.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.MediathekViewDL.Api;
+using Jellyfin.Plugin.MediathekViewDL.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.MediathekViewDL.Services;
+
+/// <summary>
+/// Service responsible for searching and filtering content for subscriptions.
+/// </summary>
+public class SubscriptionProcessor
+{
+    private readonly ILogger<SubscriptionProcessor> _logger;
+    private readonly MediathekViewApiClient _apiClient;
+    private readonly VideoParser _videoParser;
+    private readonly LocalMediaScanner _localMediaScanner;
+    private readonly FileNameBuilderService _fileNameBuilderService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubscriptionProcessor"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="apiClient">The API client.</param>
+    /// <param name="videoParser">The video parser.</param>
+    /// <param name="localMediaScanner">The local media scanner.</param>
+    /// <param name="fileNameBuilderService">The file name builder service.</param>
+    public SubscriptionProcessor(
+        ILogger<SubscriptionProcessor> logger,
+        MediathekViewApiClient apiClient,
+        VideoParser videoParser,
+        LocalMediaScanner localMediaScanner,
+        FileNameBuilderService fileNameBuilderService)
+    {
+        _logger = logger;
+        _apiClient = apiClient;
+        _videoParser = videoParser;
+        _localMediaScanner = localMediaScanner;
+        _fileNameBuilderService = fileNameBuilderService;
+    }
+
+    /// <summary>
+    /// Processes a subscription to find new download jobs.
+    /// </summary>
+    /// <param name="subscription">The subscription to process.</param>
+    /// <param name="downloadSubtitles">Whether to download subtitles globally.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A list of download jobs.</returns>
+    public async Task<List<DownloadJob>> GetJobsForSubscriptionAsync(
+        Subscription subscription,
+        bool downloadSubtitles,
+        CancellationToken cancellationToken)
+    {
+        var jobs = new List<DownloadJob>();
+
+        LocalEpisodeCache? localEpisodeCache = null;
+        if (subscription.EnhancedDuplicateDetection)
+        {
+            var subscriptionBaseDir = _fileNameBuilderService.GetSubscriptionBaseDirectory(subscription);
+            if (!string.IsNullOrWhiteSpace(subscriptionBaseDir))
+            {
+                localEpisodeCache = _localMediaScanner.ScanDirectory(subscriptionBaseDir, subscription.Name);
+            }
+        }
+
+        var currentPage = 0;
+        var hasMoreResults = true;
+        var pageSize = 50;
+        var maxPages = 20;
+
+        while (hasMoreResults && currentPage < maxPages)
+        {
+            var apiQuery = new ApiQuery
+            {
+                Queries = subscription.Queries,
+                Size = pageSize,
+                Offset = currentPage * pageSize,
+                MinDuration = subscription.MinDurationMinutes.HasValue ? subscription.MinDurationMinutes * 60 : null,
+                MaxDuration = subscription.MaxDurationMinutes.HasValue ? subscription.MaxDurationMinutes * 60 : null
+            };
+
+            var result = await _apiClient.SearchAsync(apiQuery, cancellationToken).ConfigureAwait(false);
+            if (result?.QueryInfo?.TotalResults > (currentPage + 1) * pageSize)
+            {
+                hasMoreResults = true;
+                currentPage++;
+            }
+            else
+            {
+                hasMoreResults = false;
+            }
+
+            var results = result?.Results;
+            if (results == null)
+            {
+                _logger.LogWarning("Could not retrieve search results for subscription '{SubscriptionName}'.", subscription.Name);
+                continue;
+            }
+
+            foreach (var item in results)
+            {
+                if (subscription.ProcessedItemIds.Contains(item.Id))
+                {
+                    _logger.LogDebug("Skipping item '{Title}' (ID: {Id}) as it was already processed for subscription '{SubscriptionName}'.", item.Title, item.Id, subscription.Name);
+                    continue;
+                }
+
+                var tempVideoInfo = _videoParser.ParseVideoInfo(subscription.Name, item.Title);
+                if (tempVideoInfo == null)
+                {
+                    _logger.LogDebug("Skipping item '{Title}' due to video info parsing failure.", item.Title);
+                    continue;
+                }
+
+                if (localEpisodeCache != null && localEpisodeCache.Contains(tempVideoInfo))
+                {
+                    _logger.LogInformation(
+                        "Skipping item '{Title}' (S{Season}E{Episode} / Abs: {Abs}) as it was found locally via enhanced duplicate detection.",
+                        item.Title,
+                        tempVideoInfo.SeasonNumber,
+                        tempVideoInfo.EpisodeNumber,
+                        tempVideoInfo.AbsoluteEpisodeNumber);
+
+                    subscription.ProcessedItemIds.Add(item.Id);
+                    continue;
+                }
+
+                if (!subscription.AllowAudioDescription && tempVideoInfo.HasAudiodescription)
+                {
+                    _logger.LogDebug("Skipping item '{Title}' due to Audiodescription and subscription preference.", item.Title);
+                    continue;
+                }
+
+                if (!subscription.AllowSignLanguage && tempVideoInfo.HasSignLanguage)
+                {
+                    _logger.LogDebug("Skipping item '{Title}' due to Sign Language and subscription preference.", item.Title);
+                    continue;
+                }
+
+                if (subscription.EnforceSeriesParsing && !tempVideoInfo.IsShow)
+                {
+                    _logger.LogDebug("Skipping item '{Title}' due to EnforceSeriesParsing and parsing result.", item.Title);
+                    continue;
+                }
+
+                if (subscription is { EnforceSeriesParsing: true, AllowAbsoluteEpisodeNumbering: false } && tempVideoInfo is { HasSeasonEpisodeNumbering: false })
+                {
+                    _logger.LogDebug("Skipping item '{Title}' due to absolute episode numbering and subscription preference.", item.Title);
+                    continue;
+                }
+
+                var paths = _fileNameBuilderService.GenerateDownloadPaths(tempVideoInfo, subscription);
+                if (!paths.IsValid)
+                {
+                    continue;
+                }
+
+                var videoUrl = item.UrlVideoHd ?? item.UrlVideo ?? item.UrlVideoLow;
+                if (string.IsNullOrWhiteSpace(videoUrl))
+                {
+                    _logger.LogWarning("No video URL found for item '{Title}'.", item.Title);
+                    continue;
+                }
+
+                // Video/Main Job
+                var mainJob = new DownloadJob
+                {
+                    ItemId = item.Id,
+                    Title = tempVideoInfo.Title,
+                    SourceUrl = videoUrl
+                };
+
+                if (subscription.UseStreamingUrlFiles)
+                {
+                    mainJob.JobType = DownloadType.StreamingUrl;
+                    mainJob.DestinationPath = paths.StrmFilePath;
+                }
+                else if (tempVideoInfo.Language == "deu" || subscription.DownloadFullVideoForSecondaryAudio)
+                {
+                    mainJob.JobType = DownloadType.DirectDownload;
+                    mainJob.DestinationPath = paths.MainFilePath;
+                }
+                else
+                {
+                    mainJob.JobType = DownloadType.AudioExtraction;
+                    mainJob.DestinationPath = paths.MainFilePath;
+                    mainJob.AudioLanguage = tempVideoInfo.Language;
+                }
+
+                jobs.Add(mainJob);
+
+                // Subtitle Job
+                if (downloadSubtitles && !string.IsNullOrWhiteSpace(item.UrlSubtitle))
+                {
+                    jobs.Add(new DownloadJob
+                    {
+                        ItemId = item.Id,
+                        Title = $"{tempVideoInfo.Title} (Subtitle)",
+                        SourceUrl = item.UrlSubtitle,
+                        DestinationPath = paths.SubtitleFilePath,
+                        JobType = DownloadType.DirectDownload
+                    });
+                }
+            }
+        }
+
+        return jobs;
+    }
+}

--- a/Jellyfin.Plugin.MediathekViewDL/Tasks/DownloadScheduledTask.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Tasks/DownloadScheduledTask.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Jellyfin.Plugin.MediathekViewDL.Api;
-using Jellyfin.Plugin.MediathekViewDL.Configuration;
 using Jellyfin.Plugin.MediathekViewDL.Services;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
@@ -20,47 +17,27 @@ namespace Jellyfin.Plugin.MediathekViewDL.Tasks;
 public class DownloadScheduledTask : IScheduledTask
 {
     private readonly ILogger<DownloadScheduledTask> _logger;
-    private readonly IServerConfigurationManager _configurationManager;
-    private readonly MediathekViewApiClient _apiClient;
-    private readonly FFmpegService _ffmpegService;
     private readonly ILibraryManager _libraryManager;
-    private readonly VideoParser _videoParser;
-    private readonly FileDownloader _fileDownloader;
-    private readonly FileNameBuilderService _fileNameBuilderService;
-    private readonly LocalMediaScanner _localMediaScanner;
+    private readonly SubscriptionProcessor _subscriptionProcessor;
+    private readonly DownloadManager _downloadManager;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DownloadScheduledTask"/> class.
     /// </summary>
     /// <param name="logger">The logger.</param>
-    /// <param name="configurationManager">The server configuration manager.</param>
-    /// <param name="apiClient">The MediathekView API client.</param>
-    /// <param name="ffmpegService">The FFmpeg service.</param>
     /// <param name="libraryManager">The library manager.</param>
-    /// <param name="videoParser">The video parser.</param>
-    /// <param name="fileDownloader">The file downloader.</param>
-    /// <param name="fileNameBuilderService">The file name builder service.</param>
-    /// <param name="localMediaScanner">The local media scanner.</param>
+    /// <param name="subscriptionProcessor">The subscription processor.</param>
+    /// <param name="downloadManager">The download manager.</param>
     public DownloadScheduledTask(
         ILogger<DownloadScheduledTask> logger,
-        IServerConfigurationManager configurationManager,
-        MediathekViewApiClient apiClient,
-        FFmpegService ffmpegService,
         ILibraryManager libraryManager,
-        VideoParser videoParser,
-        FileDownloader fileDownloader,
-        FileNameBuilderService fileNameBuilderService,
-        LocalMediaScanner localMediaScanner)
+        SubscriptionProcessor subscriptionProcessor,
+        DownloadManager downloadManager)
     {
         _logger = logger;
-        _configurationManager = configurationManager;
-        _apiClient = apiClient;
-        _ffmpegService = ffmpegService;
         _libraryManager = libraryManager;
-        _videoParser = videoParser;
-        _fileDownloader = fileDownloader;
-        _fileNameBuilderService = fileNameBuilderService;
-        _localMediaScanner = localMediaScanner;
+        _subscriptionProcessor = subscriptionProcessor;
+        _downloadManager = downloadManager;
     }
 
     /// <inheritdoc />
@@ -96,7 +73,6 @@ public class DownloadScheduledTask : IScheduledTask
         }
 
         var newLastRun = DateTime.UtcNow;
-
         var subscriptions = config.Subscriptions.ToList();
         var subscriptionProgressShare = subscriptions.Count > 0 ? 100.0 / subscriptions.Count : 0;
 
@@ -116,297 +92,45 @@ public class DownloadScheduledTask : IScheduledTask
 
             _logger.LogInformation("Processing subscription: {SubscriptionName}", subscription.Name);
 
-            LocalEpisodeCache? localEpisodeCache = null;
-            if (subscription.EnhancedDuplicateDetection)
-            {
-                var subscriptionBaseDir = _fileNameBuilderService.GetSubscriptionBaseDirectory(subscription);
-                if (!string.IsNullOrWhiteSpace(subscriptionBaseDir))
-                {
-                    localEpisodeCache = _localMediaScanner.ScanDirectory(subscriptionBaseDir, subscription.Name);
-                }
-            }
+            // Step 1: Find jobs
+            var jobs = await _subscriptionProcessor.GetJobsForSubscriptionAsync(
+                subscription,
+                config.DownloadSubtitles,
+                cancellationToken).ConfigureAwait(false);
 
-            // Stage 1: Collect all items for the current subscription
-            var allItemsToDownload = new List<VideoParseResult>();
-            var currentPage = 0;
-            var hasMoreResults = true;
-            var pageSize = 50;
-            var maxPages = 20; // Limit to avoid excessive requests. Adjust as needed. Should be enough for most cases.
+            _logger.LogInformation("Found {Count} new items for '{SubscriptionName}'.", jobs.Count, subscription.Name);
 
-            // Paginate through results for the subscription
-            while (hasMoreResults && currentPage < maxPages)
-            {
-                var apiQuery = new ApiQuery
-                {
-                    Queries = subscription.Queries,
-                    Size = pageSize,
-                    Offset = currentPage * pageSize,
-                    MinDuration = subscription.MinDurationMinutes.HasValue ? subscription.MinDurationMinutes * 60 : null,
-                    MaxDuration = subscription.MaxDurationMinutes.HasValue ? subscription.MaxDurationMinutes * 60 : null
-                };
-
-                var result = await _apiClient.SearchAsync(apiQuery, cancellationToken).ConfigureAwait(false);
-                if (result?.QueryInfo?.TotalResults > (currentPage + 1) * pageSize)
-                {
-                    hasMoreResults = true;
-                    currentPage++;
-                }
-                else
-                {
-                    hasMoreResults = false;
-                }
-
-                var results = result?.Results;
-                if (results == null)
-                {
-                    _logger.LogWarning("Could not retrieve search results for subscription '{SubscriptionName}'.", subscription.Name);
-                    continue;
-                }
-
-                foreach (var item in results)
-                {
-                    // Skip if already processed for this subscription
-                    if (subscription.ProcessedItemIds.Contains(item.Id))
-                    {
-                        _logger.LogDebug("Skipping item '{Title}' (ID: {Id}) as it was already processed for subscription '{SubscriptionName}'.", item.Title, item.Id, subscription.Name);
-                        continue;
-                    }
-
-                    var tempVideoInfo = _videoParser.ParseVideoInfo(subscription.Name, item.Title);
-                    if (tempVideoInfo == null)
-                    {
-                        _logger.LogDebug("Skipping item '{Title}' due to video info parsing failure.", item.Title);
-                        continue;
-                    }
-
-                    // Enhanced Duplicate Detection Check
-                    if (localEpisodeCache != null &&
-                        localEpisodeCache.Contains(tempVideoInfo))
-                    {
-                        _logger.LogInformation(
-                            "Skipping item '{Title}' (S{Season}E{Episode} / Abs: {Abs}) as it was found locally via enhanced duplicate detection.",
-                            item.Title,
-                            tempVideoInfo.SeasonNumber,
-                            tempVideoInfo.EpisodeNumber,
-                            tempVideoInfo.AbsoluteEpisodeNumber);
-
-                        // Mark as processed so we don't scan it again in future runs (optional, but good for performance)
-                        subscription.ProcessedItemIds.Add(item.Id);
-                        continue;
-                    }
-
-                    // Check Audiodescription preference
-                    if (!subscription.AllowAudioDescription && tempVideoInfo.HasAudiodescription)
-                    {
-                        _logger.LogDebug("Skipping item '{Title}' due to Audiodescription and subscription preference.", item.Title);
-                        continue;
-                    }
-
-                    // Check Sign Language preference
-                    if (!subscription.AllowSignLanguage && tempVideoInfo.HasSignLanguage)
-                    {
-                        _logger.LogDebug("Skipping item '{Title}' due to Sign Language and subscription preference.", item.Title);
-                        continue;
-                    }
-
-                    // Check if Show is required
-                    if (subscription.EnforceSeriesParsing && !tempVideoInfo.IsShow)
-                    {
-                        _logger.LogDebug("Skipping item '{Title}' due to EnforceSeriesParsing and parsing result.", item.Title);
-                        continue;
-                    }
-
-                    // Check if Season/Episode parsing is required
-                    if (subscription is { EnforceSeriesParsing: true, AllowAbsoluteEpisodeNumbering: false } && tempVideoInfo is { HasSeasonEpisodeNumbering: false })
-                    {
-                        _logger.LogDebug("Skipping item '{Title}' due to absolute episode numbering and subscription preference.", item.Title);
-                        continue;
-                    }
-
-                    allItemsToDownload.Add(new VideoParseResult { Item = item!, VideoInfo = tempVideoInfo });
-                }
-            }
-
-            _logger.LogInformation("Found {Count} new, filtered items for '{SubscriptionName}'.", allItemsToDownload.Count, subscription.Name);
-
-            var hasDownloadedAnyItem = false;
-
-            // Stage 2: Download collected items and report progress
-            var numItemsToDownload = allItemsToDownload.Count;
-            if (numItemsToDownload == 0)
+            var numJobs = jobs.Count;
+            if (numJobs == 0)
             {
                 progress.Report(baseProgressForSubscription + subscriptionProgressShare);
                 continue;
             }
 
-            var progressPerItem = subscriptionProgressShare / numItemsToDownload;
+            var progressPerJob = subscriptionProgressShare / numJobs;
+            var hasDownloadedAnyItem = false;
 
-            for (int j = 0; j < numItemsToDownload; j++)
+            // Step 2: Execute jobs
+            for (int j = 0; j < numJobs; j++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var item = allItemsToDownload[j];
-                var baseProgressForItem = baseProgressForSubscription + (j * progressPerItem);
+                var job = jobs[j];
+                var baseProgressForJob = baseProgressForSubscription + (j * progressPerJob);
 
-                var paths = _fileNameBuilderService.GenerateDownloadPaths(item.VideoInfo, subscription);
-                if (!paths.IsValid)
+                var jobProgress = new Progress<double>(p =>
                 {
-                    // Error logged in service
-                    continue;
-                }
-
-                // Ensure target directory exists
-                if (!Directory.Exists(paths.DirectoryPath))
-                {
-                    Directory.CreateDirectory(paths.DirectoryPath);
-                }
-
-                // --- Handle Video/Audio ---
-                var videoUrl = item.Item.UrlVideoHd ?? item.Item.UrlVideo ?? item.Item.UrlVideoLow;
-
-                var downloadProgress = new Progress<double>(p =>
-                {
-                    var itemDownloadProgress = p / 100.0 * progressPerItem;
-                    progress.Report(baseProgressForItem + itemDownloadProgress);
+                    var itemDownloadProgress = p / 100.0 * progressPerJob;
+                    progress.Report(baseProgressForJob + itemDownloadProgress);
                 });
 
-                if (subscription.UseStreamingUrlFiles)
+                if (await _downloadManager.ExecuteJobAsync(job, jobProgress, cancellationToken).ConfigureAwait(false))
                 {
-                    if (!File.Exists(paths.StrmFilePath))
-                    {
-                        _logger.LogInformation(
-                            "Creating streaming URL file for '{Title}' at '{Path}'",
-                            item.VideoInfo.Title,
-                            paths.StrmFilePath);
-                        await _fileDownloader.GenerateStreamingUrlFileAsync(videoUrl, paths.StrmFilePath, cancellationToken).ConfigureAwait(false);
-                        subscription.ProcessedItemIds.Add(item.Item.Id);
-                        hasDownloadedAnyItem = true;
-                    }
-                    else
-                    {
-                        _logger.LogDebug("Streaming URL file for '{Title}' already exists.", item.VideoInfo.Title);
-                        subscription.ProcessedItemIds.Add(item.Item.Id);
-                        hasDownloadedAnyItem = true;
-                    }
-                }
-                else if (item.VideoInfo.Language == "deu")
-                {
-                    if (!File.Exists(paths.MainFilePath))
-                    {
-                        _logger.LogInformation("Downloading master video for '{Title}' to '{Path}'", item.VideoInfo.Title, paths.MainFilePath);
-                        if (await _fileDownloader.DownloadFileAsync(videoUrl, paths.MainFilePath, downloadProgress, cancellationToken).ConfigureAwait(false))
-                        {
-                            _logger.LogInformation("Successfully finished master video download of '{Title}'.", item.VideoInfo.Title);
-                            subscription.ProcessedItemIds.Add(item.Item.Id);
-                            hasDownloadedAnyItem = true;
-                        }
-                        else
-                        {
-                            _logger.LogError("Failed to download master video for '{Title}'.", item.VideoInfo.Title);
-                            // Do not add to ProcessedItemIds if download failed to retry later
-                        }
-                    }
-                    else
-                    {
-                        _logger.LogDebug("Master video for '{Title}' already exists.", item.VideoInfo.Title);
-                        subscription.ProcessedItemIds.Add(item.Item.Id);
-                        hasDownloadedAnyItem = true;
-                    }
-                }
-                else // Non-German version: handle based on subscription setting
-                {
-                    if (subscription.DownloadFullVideoForSecondaryAudio)
-                    {
-                        if (!File.Exists(paths.MainFilePath))
-                        {
-                            _logger.LogInformation("Downloading full video for '{Title}' ({Language}) to '{Path}' based on subscription setting.", item.VideoInfo.Title, item.VideoInfo.Language, paths.MainFilePath);
-                            if (await _fileDownloader.DownloadFileAsync(videoUrl, paths.MainFilePath, downloadProgress, cancellationToken).ConfigureAwait(false))
-                            {
-                                _logger.LogInformation("Successfully finished full video download of '{Title}'.", item.VideoInfo.Title);
-                                subscription.ProcessedItemIds.Add(item.Item.Id);
-                                hasDownloadedAnyItem = true;
-                            }
-                            else
-                            {
-                                _logger.LogError("Failed to download full video for '{Title}'.", item.VideoInfo.Title);
-                                // Do not add to ProcessedItemIds if download failed to retry later
-                            }
-                        }
-                        else
-                        {
-                            _logger.LogDebug("Full video for '{Title}' ({Language}) already exists.", item.VideoInfo.Title, item.VideoInfo.Language);
-                            subscription.ProcessedItemIds.Add(item.Item.Id);
-                            hasDownloadedAnyItem = true;
-                        }
-                    }
-                    else // Existing logic: extract audio if not exists
-                    {
-                        if (!File.Exists(paths.MainFilePath))
-                        {
-                            var tempVideoPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.mp4"); // Temp path for non-DE video download
-                            _logger.LogInformation("Downloading temporary video for '{Title}' to extract '{Language}' audio.", item.VideoInfo.Title, item.VideoInfo.Language);
-                            if (!await _fileDownloader.DownloadFileAsync(videoUrl, tempVideoPath, downloadProgress, cancellationToken).ConfigureAwait(false))
-                            {
-                                _logger.LogError("Failed to download temporary video for '{Title}'.", item.VideoInfo.Title);
-                                // Do not add to ProcessedItemIds if download failed to retry later
-                                continue;
-                            }
-
-                            _logger.LogInformation("Extracting '{Language}' audio for '{Title}' to '{Path}'.", item.VideoInfo.Language, item.VideoInfo.Title, paths.MainFilePath);
-                            if (await _ffmpegService.ExtractAudioAsync(tempVideoPath, paths.MainFilePath, item.VideoInfo.Language, cancellationToken).ConfigureAwait(false))
-                            {
-                                _logger.LogInformation("Successfully extracted '{Language}' audio for '{Title}'.", item.VideoInfo.Language, item.VideoInfo.Title);
-                                subscription.ProcessedItemIds.Add(item.Item.Id);
-                                hasDownloadedAnyItem = true;
-                            }
-                            else
-                            {
-                                _logger.LogError("Failed to extract audio for '{Title}'.", item.VideoInfo.Title);
-                                // Do not add to ProcessedItemIds if extraction failed to retry later
-                            }
-
-                            // Clean up temporary video file
-                            if (File.Exists(tempVideoPath))
-                            {
-                                File.Delete(tempVideoPath);
-                            }
-                        }
-                        else
-                        {
-                            _logger.LogDebug("External '{Language}' audio for '{Title}' already exists.", item.VideoInfo.Language, item.VideoInfo.Title);
-                            subscription.ProcessedItemIds.Add(item.Item.Id);
-                            hasDownloadedAnyItem = true;
-                        }
-                    }
+                    subscription.ProcessedItemIds.Add(job.ItemId);
+                    hasDownloadedAnyItem = true;
                 }
 
-                // --- Handle Subtitles ---
-                if (config.DownloadSubtitles && !string.IsNullOrWhiteSpace(item.Item.UrlSubtitle))
-                {
-                    if (!File.Exists(paths.SubtitleFilePath))
-                    {
-                        _logger.LogInformation("Downloading '{Language}' subtitle for '{Title}' to '{Path}'.", item.VideoInfo.Language, item.VideoInfo.Title, paths.SubtitleFilePath);
-                        if (await _fileDownloader.DownloadFileAsync(item.Item.UrlSubtitle, paths.SubtitleFilePath, new Progress<double>(), cancellationToken).ConfigureAwait(false))
-                        {
-                            _logger.LogInformation("Successfully finished subtitle download of '{Title}'.", item.VideoInfo.Title);
-                            subscription.ProcessedItemIds.Add(item.Item.Id);
-                            hasDownloadedAnyItem = true;
-                        }
-                        else
-                        {
-                            _logger.LogError("Failed to download subtitle for '{Title}'.", item.VideoInfo.Title);
-                            // Do not add to ProcessedItemIds if download failed to retry later
-                        }
-                    }
-                    else
-                    {
-                        _logger.LogDebug("Subtitle in '{Language}' for '{Title}' already exists.", item.VideoInfo.Language, item.VideoInfo.Title);
-                        subscription.ProcessedItemIds.Add(item.Item.Id);
-                        hasDownloadedAnyItem = true;
-                    }
-                }
-
-                progress.Report(baseProgressForItem + progressPerItem);
+                progress.Report(baseProgressForJob + progressPerJob);
             }
 
             if (hasDownloadedAnyItem)
@@ -425,12 +149,5 @@ public class DownloadScheduledTask : IScheduledTask
 
         progress.Report(100);
         _logger.LogInformation("Mediathek subscription download task finished.");
-    }
-
-    private sealed class VideoParseResult
-    {
-        public ResultItem Item { get; set; } = null!;
-
-        public VideoInfo VideoInfo { get; set; } = null!;
     }
 }


### PR DESCRIPTION
This PR addresses issue #4 by refactoring the `DownloadScheduledTask.ExecuteAsync` method, which was previously a "God Method" mixing API querying, filtering, and downloading logic.
   
**Key Changes:**
*   **`SubscriptionProcessor`**: A new service responsible for finding and filtering content. It queries the MediathekView API, applies user filters (duration, seen status, series parsing), and return a list of actionable `DownloadJob`s.
*  *   **`DownloadManager`**: A new service responsible for executing the download jobs. It handles direct downloads, audio extraction (via FFmpeg), and .strm file generation. It also correctly utilizes
     `IServerApplicationPaths` for temporary file management.
*   **`DownloadJob` & `DownloadType`**: Introduced a DTO and Enum to decouple the *decision* of what to download from the *execution* of the download.
*   **`DownloadScheduledTask`**: Simplified to an orchestrator that coordinates the `SubscriptionProcessor` and `DownloadManager`, adhering to the Single Responsibility Principle.
   
This refactoring improves code readability, testability, and paves the way for future improvements like a persistent download queue.