### PR TITLE
feat: Add option to toggle automatic library scan after download

### DIFF
--- a/Jellyfin.Plugin.MediathekViewDL/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Configuration/PluginConfiguration.cs
@@ -44,6 +44,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool AllowUnknownDomains { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets a value indicating whether a library scan should be triggered after a download finishes.
+    /// </summary>
+    public bool ScanLibraryAfterDownload { get; set; } = true;
+
+    /// <summary>
     /// Gets the list of download subscriptions.
     /// </summary>
     public Collection<Subscription> Subscriptions { get; init; }

--- a/Jellyfin.Plugin.MediathekViewDL/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MediathekViewDL/Configuration/configPage.html
@@ -111,6 +111,14 @@
                                     das ich die Whitelist ggf. erweitern kann.</div>
                             </div>
 
+                            <div class="checkboxContainer checkboxContainer-withDescription" style="margin-top: 20px;">
+                                <label class="emby-checkbox-label">
+                                    <input id="chkScanLibraryAfterDownload" type="checkbox" is="emby-checkbox" />
+                                    <span>Bibliotheksscan nach Download</span>
+                                </label>
+                                <div class="fieldDescription">Startet automatisch einen Scan der Medienbibliothek, nachdem neue Inhalte heruntergeladen wurden. Wenn deaktiviert, erscheinen neue Inhalte erst nach dem nächsten regulären Scan.</div>
+                            </div>
+
                             <div class="inputContainer">
                                 <label class="inputLabel" for="txtMinFreeDiskSpaceMiB">Mindestfreier Speicherplatz
                                     (MiB)</label>
@@ -706,6 +714,7 @@
                         document.querySelector('#txtDefaultDownloadPath').value = config.DefaultDownloadPath || "";
                         document.querySelector('#chkDownloadSubtitles').checked = config.DownloadSubtitles;
                         document.querySelector('#chkAllowUnknownDomains').checked = config.AllowUnknownDomains;
+                        document.querySelector('#chkScanLibraryAfterDownload').checked = config.ScanLibraryAfterDownload;
                         document.querySelector('#txtMinFreeDiskSpaceMiB').value = config.MinFreeDiskSpaceBytes ? (config.MinFreeDiskSpaceBytes / (1024 * 1024)) : "";
                         document.querySelector('#lblLastRun').innerText = config.LastRun ? new Date(config.LastRun).toLocaleString() : "Noch nie";
 
@@ -1142,6 +1151,7 @@
                         this.currentConfig.DefaultDownloadPath = document.querySelector('#txtDefaultDownloadPath').value;
                         this.currentConfig.DownloadSubtitles = document.querySelector('#chkDownloadSubtitles').checked;
                         this.currentConfig.AllowUnknownDomains = document.querySelector('#chkAllowUnknownDomains').checked;
+                        this.currentConfig.ScanLibraryAfterDownload = document.querySelector('#chkScanLibraryAfterDownload').checked;
                         const minFreeSpaceMiB = parseInt(document.querySelector('#txtMinFreeDiskSpaceMiB').value, 10);
                         this.currentConfig.MinFreeDiskSpaceBytes = isNaN(minFreeSpaceMiB) ? (1.5 * 1024 * 1024 * 1024) : (minFreeSpaceMiB * 1024 * 1024);
                         this.saveGlobalConfig();

--- a/Jellyfin.Plugin.MediathekViewDL/Tasks/DownloadScheduledTask.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Tasks/DownloadScheduledTask.cs
@@ -144,8 +144,15 @@ public class DownloadScheduledTask : IScheduledTask
         Plugin.Instance?.UpdateConfiguration(config);
 
         // Trigger library scans
-        _logger.LogInformation("Triggering library scan");
-        _libraryManager.QueueLibraryScan();
+        if (config.ScanLibraryAfterDownload)
+        {
+            _logger.LogInformation("Triggering library scan");
+            _libraryManager.QueueLibraryScan();
+        }
+        else
+        {
+            _logger.LogInformation("Library scan skipped (configured in settings).");
+        }
 
         progress.Report(100);
         _logger.LogInformation("Mediathek subscription download task finished.");


### PR DESCRIPTION
This PR introduces a new configuration option allowing users to enable or disable the automatic library scan after new subscription content has been downloaded.

  Key changes include:
   - Added a ScanLibraryAfterDownload boolean property to PluginConfiguration.cs with a default value of true.
   - Integrated a corresponding checkbox into configPage.html for user management of this setting.
   - Modified DownloadScheduledTask.cs to conditionally trigger the library scan based on the user's preference set by the new configuration option.