### PR TITLE
feat: Add download bandwidth limiting

### DIFF
--- a/Jellyfin.Plugin.MediathekViewDL/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Configuration/PluginConfiguration.cs
@@ -37,6 +37,12 @@ public class PluginConfiguration : BasePluginConfiguration
     public long MinFreeDiskSpaceBytes { get; set; } = (long)(1.5 * 1024 * 1024 * 1024); // Default to 1.5 GiB
 
     /// <summary>
+    /// Gets or sets the maximum download bandwidth in MBit/s.
+    /// 0 means unlimited.
+    /// </summary>
+    public int MaxBandwidthMBits { get; set; } = 0;
+
+    /// <summary>
     /// Gets or sets a value indicating whether downloads from unknown domains are allowed.
     /// This may be usefull if ARD or ZDF adds new CDNs that are not yet whitelisted.
     /// This may pose a security risk, so use with caution.

--- a/Jellyfin.Plugin.MediathekViewDL/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MediathekViewDL/Configuration/configPage.html
@@ -135,6 +135,12 @@
                         </div>
 
                         <div class="inputContainer">
+                            <label class="inputLabel" for="txtMaxBandwidthMBits">Maximale Download-Bandbreite (MBit/s)</label>
+                            <input is="emby-input" type="number" id="txtMaxBandwidthMBits"/>
+                            <div class="fieldDescription">Begrenzt die Download-Geschwindigkeit. 0 bedeutet unbegrenzt.</div>
+                        </div>
+
+                        <div class="inputContainer">
                             <label class="inputLabel">Letzter Lauf</label>
                             <div id="lblLastRun" class="mvpl-last-run-label">Noch nie</div>
                         </div>
@@ -825,6 +831,7 @@
                         document.querySelector('#chkScanLibraryAfterDownload').checked = config.ScanLibraryAfterDownload;
                         document.querySelector('#chkEnableStrmCleanup').checked = config.EnableStrmCleanup;
                         document.querySelector('#txtMinFreeDiskSpaceMiB').value = config.MinFreeDiskSpaceBytes ? (config.MinFreeDiskSpaceBytes / (1024 * 1024)) : "";
+                        document.querySelector('#txtMaxBandwidthMBits').value = config.MaxBandwidthMBits || 0;
                         document.querySelector('#lblLastRun').innerText = config.LastRun ? new Date(config.LastRun).toLocaleString() : "Noch nie";
 
                         this.renderSubscriptionsList();
@@ -1387,6 +1394,10 @@
                         this.currentConfig.EnableStrmCleanup = document.querySelector('#chkEnableStrmCleanup').checked;
                         const minFreeSpaceMiB = parseInt(document.querySelector('#txtMinFreeDiskSpaceMiB').value, 10);
                         this.currentConfig.MinFreeDiskSpaceBytes = isNaN(minFreeSpaceMiB) ? (1.5 * 1024 * 1024 * 1024) : (minFreeSpaceMiB * 1024 * 1024);
+
+                        const maxBandwidth = parseInt(document.querySelector('#txtMaxBandwidthMBits').value, 10);
+                        this.currentConfig.MaxBandwidthMBits = isNaN(maxBandwidth) ? 0 : maxBandwidth;
+
                         this.saveGlobalConfig();
                         return false;
                     });

--- a/Jellyfin.Plugin.MediathekViewDL/Services/Downloading/ThrottledStream.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Services/Downloading/ThrottledStream.cs
@@ -1,0 +1,149 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.RateLimiting;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.MediathekViewDL.Services.Downloading;
+
+/// <summary>
+/// A stream wrapper that throttles the reading speed using a TokenBucketRateLimiter.
+/// </summary>
+public class ThrottledStream : Stream
+{
+    private readonly Stream _innerStream;
+    private readonly TokenBucketRateLimiter _limiter;
+    private readonly int _tokenLimit;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ThrottledStream"/> class.
+    /// </summary>
+    /// <param name="innerStream">The source stream to wrap.</param>
+    /// <param name="bytesPerSecond">The maximum bytes per second to allow.</param>
+    public ThrottledStream(Stream innerStream, long bytesPerSecond)
+    {
+        if (bytesPerSecond <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bytesPerSecond), "Bandwidth limit must be greater than zero.");
+        }
+
+        _innerStream = innerStream ?? throw new ArgumentNullException(nameof(innerStream));
+        _tokenLimit = (int)bytesPerSecond;
+
+        var options = new TokenBucketRateLimiterOptions
+        {
+            TokenLimit = _tokenLimit, // Burst size equal to one second of data
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            QueueLimit = int.MaxValue, // Allow infinite queuing so AcquireAsync waits instead of failing
+            ReplenishmentPeriod = TimeSpan.FromSeconds(1),
+            TokensPerPeriod = _tokenLimit,
+            AutoReplenishment = true
+        };
+
+        _limiter = new TokenBucketRateLimiter(options);
+    }
+
+    /// <inheritdoc />
+    public override bool CanRead => _innerStream.CanRead;
+
+    /// <inheritdoc />
+    public override bool CanSeek => _innerStream.CanSeek;
+
+    /// <inheritdoc />
+    public override bool CanWrite => _innerStream.CanWrite;
+
+    /// <inheritdoc />
+    public override long Length => _innerStream.Length;
+
+    /// <inheritdoc />
+    public override long Position
+    {
+        get => _innerStream.Position;
+        set => _innerStream.Position = value;
+    }
+
+    /// <inheritdoc />
+    public override void Flush() => _innerStream.Flush();
+
+    /// <inheritdoc />
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        // Synchronous read is also throttled but blocking
+        _limiter.AcquireAsync(Math.Min(count, _tokenLimit)).AsTask().Wait();
+        return _innerStream.Read(buffer, offset, count);
+    }
+
+    /// <inheritdoc />
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        // Request tokens for the amount we want to read.
+        // If count is larger than the bucket size, we might need to loop or just take what we can.
+        // Simple approach: The limiter will wait until tokens are available.
+        // However, TokenBucketRateLimiter will reject requests larger than TokenLimit.
+        // So we must clamp the request to the TokenLimit (which we set to bytesPerSecond).
+        int bytesToRead = Math.Min(count, _tokenLimit);
+
+        using var lease = await _limiter.AcquireAsync(bytesToRead, cancellationToken).ConfigureAwait(false);
+
+        if (lease.IsAcquired)
+        {
+#pragma warning disable CA1835 // Prefer Memory<T> overloads
+            // We consciously call the byte[] overload of the inner stream here to match the signature
+            // If the inner stream is optimized for byte[], this is better.
+            // However, CA1835 wants us to use Memory.
+            // Let's use the Memory overload if available on inner stream?
+            // Actually, Stream.ReadAsync(byte[]) base implementation calls ReadAsync(Memory).
+            // But since we are overriding it, we can just forward it properly.
+            return await _innerStream.ReadAsync(buffer, offset, bytesToRead, cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA1835
+        }
+
+        // Should not happen with QueueLimit = 0 and infinite wait, unless cancelled
+        throw new OperationCanceledException("Rate limiter acquisition failed.");
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        int bytesToRead = Math.Min(buffer.Length, _tokenLimit);
+
+        using var lease = await _limiter.AcquireAsync(bytesToRead, cancellationToken).ConfigureAwait(false);
+
+        if (lease.IsAcquired)
+        {
+            return await _innerStream.ReadAsync(buffer.Slice(0, bytesToRead), cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new OperationCanceledException("Rate limiter acquisition failed.");
+    }
+
+    /// <inheritdoc />
+    public override long Seek(long offset, SeekOrigin origin) => _innerStream.Seek(offset, origin);
+
+    /// <inheritdoc />
+    public override void SetLength(long value) => _innerStream.SetLength(value);
+
+    /// <inheritdoc />
+    public override void Write(byte[] buffer, int offset, int count) => _innerStream.Write(buffer, offset, count);
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _innerStream.Dispose();
+            _limiter.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        await _innerStream.DisposeAsync().ConfigureAwait(false);
+        _limiter.Dispose();
+        await base.DisposeAsync().ConfigureAwait(false);
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
This pull request implements the ability to limit the download bandwidth used by the plugin. This is useful for users who want to prevent the plugin from saturating their internet connection during downloads.

  Changes:
   - Configuration: Added a MaxBandwidthMBits property to PluginConfiguration and a corresponding input field in configPage.html to allow users to set a maximum bandwidth in Mbit/s.
   - Implementation: Introduced a ThrottledStream class that utilizes TokenBucketRateLimiter to enforce the specified bandwidth limit.
   - Integration: Updated FileDownloader to use ThrottledStream when a bandwidth limit is set (values > 0).