### PR TITLE
feat: Processed items a stored in DB

### DIFF
--- a/Jellyfin.Plugin.MediathekViewDL.Tests/SubscriptionProcessorTests.cs
+++ b/Jellyfin.Plugin.MediathekViewDL.Tests/SubscriptionProcessorTests.cs
@@ -104,38 +104,6 @@ namespace Jellyfin.Plugin.MediathekViewDL.Tests
         }
 
         [Fact]
-        public async Task GetJobsForSubscriptionAsync_ShouldSkip_IfAlreadyProcessed()
-        {
-            // Arrange
-            var subscription = new Subscription { Name = "TestSub" };
-            subscription.ProcessedItemIds.Add("123"); // Mark as processed
-
-            var item = new ResultItem
-            {
-                Id = "123",
-                Title = "TestTitle"
-            };
-
-            var resultChannels = new ResultChannels
-            {
-                Results = new Collection<ResultItem> { item },
-                QueryInfo = new QueryInfo { TotalResults = 1 }
-            };
-
-            _apiClientMock
-                .Setup(x => x.SearchAsync(It.IsAny<ApiQuery>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(resultChannels);
-
-            // Act
-            var jobs = await _processor.GetJobsForSubscriptionAsync(subscription, false, CancellationToken.None);
-
-            // Assert
-            Assert.Empty(jobs);
-            // Verify video parser was NOT called because we skipped early
-            _videoParserMock.Verify(x => x.ParseVideoInfo(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-        }
-
-        [Fact]
         public async Task GetJobsForSubscriptionAsync_ShouldSkip_IfFoundLocally_AndEnhancedDetectionEnabled()
         {
             // Arrange
@@ -173,8 +141,6 @@ namespace Jellyfin.Plugin.MediathekViewDL.Tests
 
             // Assert
             Assert.Empty(jobs);
-            // Verify it was added to processed list
-            Assert.Contains("456", subscription.ProcessedItemIds);
         }
 
         [Fact]

--- a/Jellyfin.Plugin.MediathekViewDL/Configuration/Subscription.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Configuration/Subscription.cs
@@ -148,10 +148,4 @@ public class Subscription
     /// This is purely for debugging and informational purposes.
     /// </summary>
     public DateTime? LastDownloadedTimestamp { get; set; }
-
-    /// <summary>
-    /// Gets a set of unique identifiers for items that have already been processed for this subscription.
-    /// This is used to avoid re-processing or re-downloading content.
-    /// </summary>
-    public HashSet<string> ProcessedItemIds { get; init; } = new();
 }

--- a/Jellyfin.Plugin.MediathekViewDL/Data/DbDownloadHistoryRepository.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Data/DbDownloadHistoryRepository.cs
@@ -180,6 +180,21 @@ public class DbDownloadHistoryRepository : IDownloadHistoryRepository
             .ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
+    public async Task RemoveBySubscriptionIdAsync(Guid subscriptionId)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<MediathekViewDlDbContext>();
+
+        await _migrator.EnsureMigratedAsync().ConfigureAwait(false);
+
+        // ExecuteDeleteAsync is more efficient in EF Core 7+ (available in .NET 9)
+        await context.DownloadHistory
+            .Where(e => e.SubscriptionId == subscriptionId)
+            .ExecuteDeleteAsync()
+            .ConfigureAwait(false);
+    }
+
     private static string HashUrl(string url)
     {
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(url));

--- a/Jellyfin.Plugin.MediathekViewDL/Data/IDownloadHistoryRepository.cs
+++ b/Jellyfin.Plugin.MediathekViewDL/Data/IDownloadHistoryRepository.cs
@@ -84,4 +84,11 @@ public interface IDownloadHistoryRepository
     /// <param name="subscriptionId">The subscription identifier.</param>
     /// <returns>A collection of download history entries.</returns>
     Task<IEnumerable<DownloadHistoryEntry>> GetBySubscriptionIdAsync(Guid subscriptionId);
+
+    /// <summary>
+    /// Removes all download history entries for a specific subscription.
+    /// </summary>
+    /// <param name="subscriptionId">The SubId.</param>
+    /// <returns>The Task.</returns>
+    Task RemoveBySubscriptionIdAsync(Guid subscriptionId);
 }


### PR DESCRIPTION
 Breaking Change / Migration Note:

 - Existing ProcessedItemIds from previous plugin versions will not be automatically migrated to the new database table. This is due to a lack of required data within the old HashSet entries needed for a proper migration to the
  database schema.

-  This change is not expected to cause issues, as the plugin's standard duplication detection mechanisms will identify and prevent re-downloading of already existing media files. New downloads will correctly populate the
  database.

Changes:   
   - Removal of ProcessedItemIds from Subscription configuration.
   - Full integration of IDownloadHistoryRepository for managing processed item history.
   - Updates to MediathekViewDlApiService to utilize the new history repository, notably in ResetProcessedItems.
   - Modifications across SubscriptionProcessor and DownloadScheduledTask to exclusively read from and write processed item status to the persistent download history.
   - Corresponding test updates reflecting these changes.

  Resolves #6